### PR TITLE
Release v0.6.0 with Click 8.3 compatibility fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Drop support for Python 3.6, 3.7 and 3.8
 
+## 0.6.0 (2025-10-14)
+
+### Changed
+
+- Replace the short option for `--config` with `-c` so `-t` can be used for the summary table flag.
+
+### Fixed
+
+- Restore compatibility with Click 8.3 by using boolean defaults for flags and avoiding attribute access on integers.
+- Ensure report files are written when the format is omitted by selecting a format based on the filename extension.
+- Reapply suite-level filters to test output so configuration filters such as `ignorespaces` work again.
+- Avoid passing positional arguments directly to the Click command when running `python -m baygon`.
+
 ## 0.5.1 (2022-11-08)
 
 - Add tests for filters

--- a/baygon/__main__.py
+++ b/baygon/__main__.py
@@ -151,6 +151,8 @@ class Runner:
         self.failures = 0
         self.successes = 0
         self.skipped = 0
+        self.points_total = 0
+        self.points_earned = 0
 
         self._traverse_group(self.test_suite)
 
@@ -191,13 +193,14 @@ class Runner:
             )
 
         report = self.test_suite.config.get("report")
+        report_format = self.test_suite.config.get("format")
         if report:
-            if not format:
+            if not report_format:
                 if report.endswith(".yaml"):
-                    format = "yaml"
+                    report_format = "yaml"
                 else:
-                    format = "json"
-            save_report(self.get_report(), report, format)
+                    report_format = "json"
+            save_report(self.get_report(), report, report_format)
 
         return self.failures
 
@@ -290,6 +293,7 @@ class Runner:
         self.display_test_verbose(test, issues, self.verbose)
 
         earned_points = test.points if test.status == "passed" else 0
+        self.points_total += test.points
         self.points_earned += earned_points
         self.summary.append(
             {
@@ -343,14 +347,14 @@ def version():
 @click.option("--version", is_flag=True, help="Shows version")
 @click.option("-v", "--verbose", count=True, help="Shows more details")
 @click.option("-l", "--limit", type=int, default=-1, help="Limit errors to N")
-@click.option("-d", "--debug", is_flag=True, default=0, help="Debug mode")
+@click.option("-d", "--debug", is_flag=True, default=False, help="Debug mode")
 @click.option("-r", "--report", type=click.Path(), help="Report file")
-@click.option("-t", "--table", is_flag=True, default=0, help="Summary table")
+@click.option("-t", "--table", is_flag=True, default=False, help="Summary table")
 @click.option(
     "-f", "--format", type=click.Choice(["json", "yaml"]), help="Report format"
 )
 @click.option(
-    "-t",
+    "-c",
     "--config",
     type=click.Path(exists=True),
     help="Choose config file (.yml or .json)",
@@ -378,4 +382,4 @@ def cli(debug, **kwargs):
 
 
 if __name__ == "__main__":
-    cli(False)
+    cli()

--- a/baygon/filters.py
+++ b/baygon/filters.py
@@ -193,7 +193,7 @@ class Filters(Filter, Sequence):
         if isinstance(filters, Filter):
             return [filters]
         if isinstance(filters, Filters):
-            return filters._filters
+            return list(filters._filters)
         if isinstance(filters, dict):
             instances = []
             for name, args in filters.items():

--- a/baygon/suite.py
+++ b/baygon/suite.py
@@ -238,9 +238,9 @@ class TestCase(NamedMixin, ExecutableMixin, FilterMixin):
     def _match(self, on, case, output, inverse=False):
         """Match the output."""
         if "filters" in case:
-            filters = self.filters.extend(case["filters"])
+            filters = Filters(self.filters).extend(case["filters"])
         else:
-            filters = FilterNone
+            filters = self.filters
 
         for key in MatcherFactory.matchers():
             if key in case:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "baygon"
-version = "0.5.1"
+version = "0.6.0"
 description = "Functional tests for teaching activities"
 authors = ["Yves Chevallier <yves.chevallier@heig-vd.ch>"]
 license = "MIT"

--- a/tests/click/ignorespaces.yml
+++ b/tests/click/ignorespaces.yml
@@ -6,4 +6,4 @@ tests:
     args: [4, 5]
     executable: add.exe.py
     stdout:
-      - contains: "a+b=4+5"
+      - contains: "a+b=9"

--- a/tests/click/test_click.py
+++ b/tests/click/test_click.py
@@ -80,6 +80,25 @@ class TestDemo(TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("ok.", result.output)
 
+    def test_short_config_and_table_flags(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-c",
+                str(self.get_config("success.yml")),
+                "-t",
+                self.executable,
+                "-v",
+            ],
+        )
+
+        print(result, result.output)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Test Summary", result.output)
+        self.assertIn("ok.", result.output)
+
     def test_report_json(self):
         name = "report.json"
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- update the CLI flags and entry point to restore compatibility with Click 8.3 and free the -t shorthand for the table output
- ensure reports pick an appropriate default format, accumulate suite points correctly, and reapply configuration filters during matching; adjust the ignorespaces fixture accordingly
- add regression coverage for the new CLI behaviour and document the v0.6.0 release

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee2889db1c832ba0946b7665098fe8