### PR TITLE
Update release workflow for PyPI publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
       - name: Install and Build
         run: cd docs && yarn install && yarn docs:build
       - name: Build and Deploy
@@ -47,18 +47,18 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - name: Install dependencies
+      - name: Install Poetry
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 setuptools setuptools_scm
-      - name: Create Dist
-        run: python setup.py sdist
-      - uses: actions/upload-artifact@v2
+          pip install poetry
+      - name: Build distribution
+        run: poetry build
+      - uses: actions/upload-artifact@v4
         with:
           name: release
           path: dist
@@ -79,12 +79,12 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: release
           path: dist/
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
## Summary
- update the release workflow to use maintained GitHub Actions versions
- build release artifacts with Poetry so tagged builds can be published to PyPI

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ee560cef04832b87d17baddc1656c1